### PR TITLE
Setting thread.daemon to True, so the main thread can be killed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,8 @@ Usage
 
     while True:
         schedule.run_pending()
+	# if you want to run the scheduler in a different thread without blocking the main thread
+	# schedule.run_continuously(1)
         time.sleep(1)
 
 Documentation

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -94,7 +94,9 @@ class Scheduler(object):
                     time.sleep(interval)
 
         continuous_thread = ScheduleThread()
+	continuous_thread.daemon = True
         continuous_thread.start()
+
         return cease_continuous_run
 
     def run_all(self, delay_seconds=0):


### PR DESCRIPTION
Setting thread.daemon to True, so the main thread can be killed with ctrl-c

If you are using schedule.run_continuously(), this change will allow the main thread to be killed via ctrl-c